### PR TITLE
raft.py: Fix undefined name in Python code

### DIFF
--- a/RAFT/raft.py
+++ b/RAFT/raft.py
@@ -103,7 +103,7 @@ class RAFT(nn.Module):
         fmap1 = fmap1.float()
         fmap2 = fmap2.float()
         if self.args.alternate_corr:
-            corr_fn = CorrBlockAlternate(fmap1, fmap2, radius=self.args.corr_radius)
+            corr_fn = AlternateCorrBlock(fmap1, fmap2, radius=self.args.corr_radius)
         else:
             corr_fn = CorrBlock(fmap1, fmap2, radius=self.args.corr_radius)
 


### PR DESCRIPTION
Change `CorrBlockAlternate` --> `AlternateCorrBlock` to fix the _undefined name_, match the import, and be in alignment with:
https://github.com/sczhou/ProPainter/blob/1cdf3771f8fe6ada7fe1a96aa60ca339324cb4a1/RAFT/corr.py#L83

% `pipx run ruff --select=E9,F63,F7,F82 .`
Error: RAFT/corr.py:71:17: F821 Undefined name `correlation_cudaz`
Error: RAFT/corr.py:79:13: F821 Undefined name `correlation_cudaz`
Error: RAFT/raft.py:106:23: F821 Undefined name `CorrBlockAlternate`