### PR TITLE
[feat]: Add new project in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ If you develop or use ProPainter in your projects, feel free to let me know. Als
 
 - Streaming ProPainter: https://github.com/osmr/propainter
 - Faster ProPainter: https://github.com/halfzm/faster-propainter
+- GPU Memory Efficient ProPainter: https://github.com/kimx3966/Effi-ProPainter
 - ProPainter WebUI: https://github.com/halfzm/ProPainter-Webui
 - ProPainter ComfyUI: https://github.com/daniabib/ComfyUI_ProPainter_Nodes
 - Cutie (video segmentation): https://github.com/hkchengrex/Cutie


### PR DESCRIPTION
What does this PR do? 

---- 

This PR introduces a new project that significantly reduces the peak GPU usage of the original ProPainter by up to 60%, effectively preventing OOM (Out-Of-Memory) issues even under higher settings. The main approach is to load tensors onto the GPU only during inference and immediately remove them when no longer needed. 