### PR TITLE
feat: Default to PNG sequence output and enhance output path/name fle…

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,19 +149,34 @@ weights
 We provide some examples in the [`inputs`](./inputs) folder. 
 Run the following commands to try it out:
 ```shell
-# The first example (object removal)
+# Example 1: Object removal with default output settings
+# Output: results/bmx-trees/bmx-trees_0000.png, ...
 python inference_propainter.py --video inputs/object_removal/bmx-trees --mask inputs/object_removal/bmx-trees_mask 
-# The second example (video completion)
-python inference_propainter.py --video inputs/video_completion/running_car.mp4 --mask inputs/video_completion/mask_square.png --height 240 --width 432
+
+# Example 2: Video completion, specifying resolution and output directory.
+# The basename of the --output path ('custom_run_1') will be used as the filename prefix.
+# Output: /path/to/my_outputs/custom_run_1/running_car/custom_run_1_0000.png, ...
+python inference_propainter.py --video inputs/video_completion/running_car.mp4 \
+                               --mask inputs/video_completion/mask_square.png \
+                               --height 240 --width 432 \
+                               --output /path/to/my_outputs/custom_run_1
 ```
 
-The results will be saved in the `results` folder.
-To test your own videos, please prepare the input `mp4 video` (or `split frames`) and `frame-wise mask(s)`.
+The script now outputs a sequence of PNG frames by default.
+- The output directory structure is `[path_from_--output_arg]/[video_name]/`. If `--output` is not specified, it defaults to `results/[video_name]/`.
+- The output filename prefix is taken from the basename of the `--output` argument's path. If `--output` is not specified (i.e., defaults to `results`), the `video_name` is used as the prefix.
+- For example, `python inference_propainter.py --video V.mp4 --mask M.png --output out/runA` will produce `out/runA/V/runA_0000.png`, etc.
+- `python inference_propainter.py --video V.mp4 --mask M.png` will produce `results/V/V_0000.png`, etc.
 
-If you want to specify the video resolution for processing or avoid running out of memory, you can set the video size of `--width` and `--height`:
+To test your own videos, please prepare the input `mp4 video` (or a folder of split frames) and `frame-wise mask(s)` (either a single mask image or a folder of masks).
+
+If you want to specify the video resolution for processing or avoid running out of memory, you can set `--width` and `--height`:
 ```shell
-# process a 576x320 video; set --fp16 to use fp16 (half precision) during inference.
-python inference_propainter.py --video inputs/video_completion/running_car.mp4 --mask inputs/video_completion/mask_square.png --height 320 --width 576 --fp16
+# Process a 576x320 video; set --fp16 to use fp16 (half precision) during inference.
+# Output: results/running_car/running_car_0000.png, ...
+python inference_propainter.py --video inputs/video_completion/running_car.mp4 \
+                               --mask inputs/video_completion/mask_square.png \
+                               --height 320 --width 576 --fp16
 ```
 
 #### 💃🏻 Interactive Demo


### PR DESCRIPTION
…xibility

This commit refactors the output mechanism of `inference_propainter.py`:

1.  **Default Output to PNG Sequence:** The script now generates a sequence of PNG frames by default. The `--save_frames` argument has been removed as this is the standard behavior.
2.  **Removed MP4 Output:** Generation of `inpaint_out.mp4` and `masked_in.mp4` has been removed to simplify output and focus on frame sequences.
3.  **Flexible Output Naming:**
    *   The `--output` argument now also dictates the filename prefix for the output PNGs. The basename of the path provided to `--output` is used as the prefix.
    *   If `--output` is not specified (defaulting to `results/`), the `video_name` (derived from the input video) is used as the filename prefix.
4.  **Simplified Output Directory:** Output PNG files are saved directly into `args.output/video_name/` (e.g., `results/myvideo/myvideo_0000.png` or `custom_output/myvideo/custom_output_0000.png`). The intermediate `frames/` subdirectory is no longer used.
5.  **RGB Format Maintained:** Output PNGs are ensured to be in RGB format.

The README.md has been updated to reflect these changes in usage and example commands.